### PR TITLE
Fix dice container clickable area extending beyond dice

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -138,6 +138,8 @@ body {
     user-select: none;
     z-index: 100;
     display: inline-block;
+    width: fit-content;
+    height: fit-content;
 }
 .dice-container:active { cursor: grabbing; }
 

--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
     <script src="js/token.js"></script>
     <script src="js/goldfish.js"></script>
     <script src="js/deck.js"></script>
+    <script src="js/dice.js"></script>
     <script src="js/mobile.js"></script>
     <!-- endbuild -->
 


### PR DESCRIPTION
## Summary
- Add `width: fit-content` and `height: fit-content` to `.dice-container` so it wraps tightly around the dice element instead of stretching to the right
- Add missing `dice.js` script include in `index.html` (was missing from dev mode)

Fixes #32

## Test plan
- [x] Spawn a d6 and d20 via Actions menu
- [x] Verify the clickable/draggable area matches the visible dice size
- [x] Verify dice don't interfere with nearby cards or other dice
- [x] Verify drag, click-to-roll, and right-click context menu still work

🤖 Generated with [Claude Code](https://claude.ai/code)