### PR TITLE
Add coin flip

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,3 +251,45 @@ body {
 .dice-d20.rolling {
     animation: dice-shake 0.15s infinite;
 }
+
+/* Coin */
+.coin-perspective {
+    width: 80px;
+    height: 80px;
+    perspective: 300px;
+}
+
+.coin {
+    width: 80px;
+    height: 80px;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 1s ease-out;
+}
+
+.coin-face {
+    position: absolute;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    backface-visibility: hidden;
+    font-weight: bold;
+    font-size: 18px;
+    color: #1a1a1a;
+    user-select: none;
+    box-shadow: inset -4px -4px 8px rgba(0,0,0,0.3), inset 2px 2px 6px rgba(255,255,255,0.3);
+}
+
+.coin-heads {
+    background: radial-gradient(circle at 38% 38%, #f5e47e, #c89010, #a07000);
+    border: 3px solid #8a6000;
+}
+
+.coin-tails {
+    background: radial-gradient(circle at 38% 38%, #e0e0e0, #aaaaaa, #888888);
+    border: 3px solid #666;
+    transform: rotateY(180deg);
+}

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
                       <li><hr class="dropdown-divider"></li>
                       <li><a class="dropdown-item" onclick="spawnDice('d6');">Roll d6</a></li>
                       <li><a class="dropdown-item" onclick="spawnDice('d20');">Roll d20</a></li>
+                      <li><a class="dropdown-item" onclick="spawnCoin();">Flip coin</a></li>
                     </ul>
                 </div>
             </div>

--- a/js/dice.js
+++ b/js/dice.js
@@ -190,6 +190,158 @@ function showDiceContextMenu(outer, inner, clientX, clientY) {
     }, 0);
 }
 
+function createCoinElement() {
+    var wrapper = document.createElement('div');
+    wrapper.className = 'coin-perspective';
+
+    var coin = document.createElement('div');
+    coin.className = 'coin';
+    coin.dataset.rotY = '0';
+
+    var heads = document.createElement('div');
+    heads.className = 'coin-face coin-heads';
+    heads.textContent = 'H';
+
+    var tails = document.createElement('div');
+    tails.className = 'coin-face coin-tails';
+    tails.textContent = 'T';
+
+    coin.appendChild(heads);
+    coin.appendChild(tails);
+    wrapper.appendChild(coin);
+    return wrapper;
+}
+
+function flipCoin(container) {
+    var coin = container.querySelector('.coin');
+    if (coin.dataset.flipping === 'true') return;
+    coin.dataset.flipping = 'true';
+
+    var result = Math.random() < 0.5 ? 'heads' : 'tails';
+    var currentRot = parseFloat(coin.dataset.rotY) || 0;
+
+    var baseRot = Math.round(currentRot / 360) * 360;
+    var landing = result === 'heads' ? 0 : 180;
+    var newRot = baseRot + 1800 + landing;
+
+    coin.dataset.rotY = newRot;
+    coin.style.transform = 'rotateY(' + newRot + 'deg)';
+
+    setTimeout(function() {
+        coin.dataset.flipping = 'false';
+    }, 1050);
+}
+
+function showCoinContextMenu(outer, clientX, clientY) {
+    var existing = document.getElementById('dice-context-menu');
+    if (existing) existing.remove();
+
+    var menu = document.createElement('div');
+    menu.id = 'dice-context-menu';
+    menu.className = 'dice-context-menu';
+    menu.style.left = (clientX + 4) + 'px';
+    menu.style.top  = (clientY + 4) + 'px';
+
+    function closeMenu() { menu.remove(); }
+
+    var itemRemove = document.createElement('div');
+    itemRemove.className = 'dice-context-menu-item';
+    itemRemove.textContent = 'Remove coin';
+    itemRemove.addEventListener('click', function() {
+        outer.remove();
+        closeMenu();
+    });
+    menu.appendChild(itemRemove);
+
+    document.body.appendChild(menu);
+
+    setTimeout(function() {
+        function onOutsideClick(e) {
+            if (!menu.contains(e.target)) {
+                closeMenu();
+                document.removeEventListener('mousedown', onOutsideClick);
+                document.removeEventListener('keydown', onEscape);
+            }
+        }
+        function onEscape(e) {
+            if (e.key === 'Escape') {
+                closeMenu();
+                document.removeEventListener('mousedown', onOutsideClick);
+                document.removeEventListener('keydown', onEscape);
+            }
+        }
+        document.addEventListener('mousedown', onOutsideClick);
+        document.addEventListener('keydown', onEscape);
+    }, 0);
+}
+
+function spawnCoin() {
+    var table = document.getElementById('table');
+    if (!table) return;
+
+    var tableRect = table.getBoundingClientRect();
+
+    var outer = document.createElement('div');
+    outer.className = 'dice-container';
+    outer.dataset.diceType = 'coin';
+
+    var startX = (tableRect.width / 2) - 40 + (Math.random() * 60 - 30);
+    var startY = (tableRect.height / 2) - 40 + (Math.random() * 60 - 30);
+    outer.style.left = startX + 'px';
+    outer.style.top  = startY + 'px';
+
+    var inner = document.createElement('div');
+    inner.className = 'dice-inner';
+    outer.appendChild(inner);
+
+    inner.appendChild(createCoinElement());
+    table.appendChild(outer);
+
+    // Initial flip
+    flipCoin(inner);
+
+    // Drag logic
+    var isDragging = false;
+    var dragStartX, dragStartY, elStartX, elStartY;
+    var dragMoved = false;
+
+    outer.addEventListener('mousedown', function(e) {
+        if (e.button !== 0) return;
+        isDragging = true;
+        dragMoved = false;
+        dragStartX = e.clientX;
+        dragStartY = e.clientY;
+        elStartX = parseInt(outer.style.left, 10) || 0;
+        elStartY = parseInt(outer.style.top,  10) || 0;
+        outer.style.cursor = 'grabbing';
+        e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', function(e) {
+        if (!isDragging) return;
+        var dx = e.clientX - dragStartX;
+        var dy = e.clientY - dragStartY;
+        if (Math.abs(dx) > 4 || Math.abs(dy) > 4) dragMoved = true;
+        outer.style.left = (elStartX + dx) + 'px';
+        outer.style.top  = (elStartY + dy) + 'px';
+    });
+
+    document.addEventListener('mouseup', function(e) {
+        if (!isDragging) return;
+        isDragging = false;
+        outer.style.cursor = 'grab';
+        if (!dragMoved) {
+            flipCoin(inner);
+        }
+    });
+
+    // Right-click → context menu
+    outer.addEventListener('contextmenu', function(e) {
+        e.preventDefault();
+        showCoinContextMenu(outer, e.clientX, e.clientY);
+    });
+}
+
 function spawnDice(type) {
     var table = document.getElementById('table');
     if (!table) return;


### PR DESCRIPTION
## Summary
- Adds a **Flip coin** option to the game menu alongside Roll d6 / Roll d20
- Left-click flips the coin with a 3D spin animation — lands on heads (gold) or tails (silver)
- Right-click opens a context menu with a **Remove coin** option
- Coin can be dragged around the table, same as dice

Closes #24

## Test plan
- [x] "Flip coin" appears in the game dropdown menu
- [x] Clicking spawns a coin in the center of the table
- [x] Left-click flips the coin with animation, landing on heads or tails
- [x] Clicking again while flipping does nothing (debounce)
- [x] Coin can be dragged to reposition
- [x] Right-click shows context menu with "Remove coin"
- [x] Removing the coin works correctly
- [x] Multiple coins can be on the table simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)