### PR TITLE
Add Commander zone

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -70,6 +70,7 @@
 #graveyard-placeholder,
 #exile-placeholder,
 #sideboard-placeholder,
+#commander-placeholder,
 #library-placeholder {
     width: 125px;
     height: 172px;
@@ -78,10 +79,19 @@
 #graveyard-title,
 #exile-title,
 #sideboard-title,
+#commander-title,
 #library-title,
 #hand-title,
 #custom-counter-label {
     cursor: pointer;
+}
+
+.commander-tax {
+    margin-top: 4px;
+    font-size: 13px;
+    color: #c8b472;
+    cursor: pointer;
+    user-select: none;
 }
 
 #hand-placeholder {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
                 <div id="table" class="row g-0"></div>
 
                 <div id="placeholder-row" class="row">
-                    <div class="col-lg-8 col-sm-4">
+                    <div class="col-lg-7 col-sm-4">
                         <strong id="hand-title" data-bs-toggle="modal" data-bs-target="#zoneModal">Hand</strong> (<span id="handTotal">0</span>)
                         <div id="hand-container" class="container-fluid g-0">
                             <div id="hand-placeholder" class="row g-0 flex-row flex-nowrap card-placeholder">
@@ -45,6 +45,11 @@
                     <div class="col-lg-1 col-sm-2">
                         <strong id="sideboard-title" data-bs-toggle="modal" data-bs-target="#zoneModal">Sideboard</strong> (<span id="sideboardTotal">0</span>)
                         <div id="sideboard-placeholder" class="card-placeholder"></div>
+                    </div>
+                    <div class="col-lg-1 col-sm-2">
+                        <strong id="commander-title" data-bs-toggle="modal" data-bs-target="#zoneModal">Commander</strong> (<span id="commanderTotal">0</span>)
+                        <div id="commander-placeholder" class="card-placeholder"></div>
+                        <div id="commander-tax" class="commander-tax" title="Left-click: +2 tax, Right-click: reset">Tax: +<span id="commander-tax-value">0</span></div>
                     </div>
                 </div>
             </div>

--- a/js/goldfish.js
+++ b/js/goldfish.js
@@ -3,6 +3,8 @@ var graveyardList = [];
 var exileList = [];
 var sideboardList = [];
 var handList = [];
+var commanderList = [];
+var commanderTax = 0;
 
 var deck = [];
 var sideboard = [];
@@ -51,6 +53,8 @@ async function init() {
     bindZoneModal("#sideboard-title", "Sideboard", signal);
     bindZoneModal("#library-title", "Library", signal);
     bindZoneModal("#graveyard-title", "Graveyard", signal);
+    bindZoneModal("#commander-title", "Commander", signal);
+    setupCommanderTax(signal);
     bindZoneModal("#hand-title", "Hand", signal);
 
     // Keyboard shortcuts
@@ -122,6 +126,9 @@ function handleKeypress(event) {
         case 109: // m
             if (hoveredCard) markCard(hoveredCard);
             break;
+        case 111: // o (cOmmander zone)
+            putCardinPlaceholder(hoveredCard, "#commander-placeholder", "Commander");
+            break;
         case 116: // t
             if (hoveredCard) tap(hoveredCard);
             break;
@@ -144,6 +151,23 @@ function retrieveSettings() {
 
     var checkbox = document.getElementById("checkbox-card-backside-lightly-played");
     if (checkbox) checkbox.checked = !!settings.useLightlyPlayedCardBackside;
+}
+
+/**
+ * Setup commander tax click handlers. Left-click adds 2, right-click resets to 0.
+ */
+function setupCommanderTax(signal) {
+    var taxEl = document.getElementById('commander-tax');
+    if (!taxEl) return;
+    taxEl.addEventListener('click', function() {
+        commanderTax += 2;
+        document.getElementById('commander-tax-value').textContent = commanderTax;
+    }, { signal: signal });
+    taxEl.addEventListener('contextmenu', function(e) {
+        e.preventDefault();
+        commanderTax = 0;
+        document.getElementById('commander-tax-value').textContent = 0;
+    }, { signal: signal });
 }
 
 function bindZoneModal(selector, id, signal) {
@@ -181,6 +205,8 @@ function GetListById(id) {
             return sideboardList;
         case "Hand":
             return handList;
+        case "Commander":
+            return commanderList;
     }
 }
 
@@ -294,6 +320,7 @@ function updateTotals() {
     document.getElementById("exileTotal").innerHTML = exileList.length;
     document.getElementById("sideboardTotal").innerHTML = sideboardList.length;
     document.getElementById("handTotal").innerHTML = handList.length;
+    document.getElementById("commanderTotal").innerHTML = commanderList.length;
 }
 
 /**
@@ -317,7 +344,7 @@ function cleanupDragSource(sourceParent, card) {
             setupClickToDraw();
             bindCardActions();
         }
-    } else if (sourceId === 'graveyard-placeholder' || sourceId === 'exile-placeholder' || sourceId === 'sideboard-placeholder') {
+    } else if (sourceId === 'graveyard-placeholder' || sourceId === 'exile-placeholder' || sourceId === 'sideboard-placeholder' || sourceId === 'commander-placeholder') {
         var zoneName = sourceId.replace('-placeholder', '');
         zoneName = zoneName.charAt(0).toUpperCase() + zoneName.slice(1);
         var list = GetListById(zoneName);
@@ -412,10 +439,11 @@ function setupDragDrop(signal) {
         putCardOnLibrary(card);
     }, signal);
 
-    // Graveyard, Exile, Sideboard drop zones
+    // Graveyard, Exile, Sideboard, Commander drop zones
     setupDroppablePlaceholder("#graveyard-placeholder", "Graveyard", signal);
     setupDroppablePlaceholder("#exile-placeholder", "Exile", signal);
     setupDroppablePlaceholder("#sideboard-placeholder", "Sideboard", signal);
+    setupDroppablePlaceholder("#commander-placeholder", "Commander", signal);
 
     // Counter drop on card faces
     tableEl.addEventListener('dragover', function(e) {
@@ -506,6 +534,8 @@ async function reset() {
     graveyardList = [];
     markedList = [];
     handList = [];
+    commanderList = [];
+    commanderTax = 0;
     libraryList = deck.slice();
     sideboardList = sideboard.slice();
 
@@ -528,6 +558,10 @@ async function reset() {
         // Flip card to the back side
         flipCard(libraryEl.querySelector('.mtg-card'), true);
     }
+
+    // Reset commander tax display
+    var taxValueEl = document.getElementById('commander-tax-value');
+    if (taxValueEl) taxValueEl.textContent = '0';
 
     // Reset life and turn counter
     var lifeYou = document.querySelector('#life-you') || document.querySelector('[id="life-you"]');


### PR DESCRIPTION
## Summary
- Adds a **Commander** zone to the bottom row alongside Graveyard, Exile, Sideboard, and Library
- Cards can be dragged into the zone or sent there by hovering and pressing `o`
- A **Tax: +N** tracker below the zone tracks commander tax — left-click adds 2, right-click resets to 0
- Clicking the zone title opens the standard zone modal to view all cards
- Zone list and tax counter both reset on game restart

Closes #22

## Test plan
- [x] Commander zone appears in the placeholder row
- [x] Cards can be dragged from the table/hand into the Commander zone
- [x] Hovering a card and pressing `o` sends it to the Commander zone
- [x] Tax tracker starts at 0, increments by 2 on left-click, resets on right-click
- [x] Clicking "Commander" title opens the zone modal showing all cards
- [x] Commander zone and tax counter reset correctly on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)