### PR TITLE
Add import deck from file

### DIFF
--- a/js/card.js
+++ b/js/card.js
@@ -207,14 +207,19 @@ function addCounter(card) {
     });
 
     // Upon ending entering text into the counter edit field we should update the counter icon
-    function handleCounterInput(event) {
-        event.stopImmediatePropagation();
-        if (event.key !== "Enter") return;
+    function applyCounter() {
         label.className = 'ms ms-counter-' + input.value + ' ms-3x counter';
         input.style.display = 'none';
     }
-    input.addEventListener("keypress", handleCounterInput);
-    input.addEventListener("focusout", handleCounterInput);
+    input.addEventListener("keypress", function(event) {
+        event.stopImmediatePropagation();
+        if (event.key !== "Enter") return;
+        applyCounter();
+    });
+    input.addEventListener("focusout", function(event) {
+        event.stopImmediatePropagation();
+        applyCounter();
+    });
 
     // Make counter draggable
     label.draggable = true;

--- a/js/deck.js
+++ b/js/deck.js
@@ -1,3 +1,44 @@
+/**
+ * Read a local deck file and populate the mainboard/sideboard textareas.
+ * Supports plain text, MTGO format (SB: prefix), and Sideboard: section headers.
+ */
+function importDeckFromFile(file) {
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function(e) {
+        var lines = e.target.result.split('\n').map(function(l) { return l.trim(); });
+        var mainboardLines = [];
+        var sideboardLines = [];
+        var inSideboard = false;
+
+        lines.forEach(function(line) {
+            if (!line) return;
+            // MTGO "SB: 4 Card Name" format
+            if (/^SB:\s+/i.test(line)) {
+                sideboardLines.push(line.replace(/^SB:\s+/i, ''));
+                return;
+            }
+            // "Sideboard:" section header
+            if (/^sideboard\s*:?\s*$/i.test(line)) {
+                inSideboard = true;
+                return;
+            }
+            if (inSideboard) {
+                sideboardLines.push(line);
+            } else {
+                mainboardLines.push(line);
+            }
+        });
+
+        document.getElementById('deck-list').value = mainboardLines.join('\n');
+        document.getElementById('sideboard-list').value = sideboardLines.join('\n');
+
+        // Reset the file input so the same file can be re-imported
+        document.getElementById('deck-file-input').value = '';
+    };
+    reader.readAsText(file);
+}
+
 async function importMtgStocksDeck(deckId) {
     const response = await fetch(`https://cors.sboulema.nl/https://api.mtgstocks.com/decks/${deckId}`);
     const result = await response.json();
@@ -67,9 +108,6 @@ async function loadDeck() {
     deck = libraryList.slice();
     shuffleDeck();
     draw(7);
-    updateTotals();
-    bindCardActions();
-    setupClickToDraw();
 
     // Place card on top of library
     var libraryEl = document.getElementById("library-placeholder");
@@ -80,11 +118,15 @@ async function loadDeck() {
         flipCard(libraryEl.querySelector('.mtg-card'), true);
     }
 
+    updateTotals();
+    bindCardActions();
+    setupClickToDraw();
+
     // Sideboard
     var sideboardVal = document.getElementById("sideboard-list").value;
     if (sideboardVal != '') {
         result = await parseCardList(sideboardVal);
-        sideboardList = result.sideboardList;
+        sideboardList = result.cards;
 
         document.getElementById("sideboard-placeholder").appendChild(defaultCard());
         sideboard = sideboardList.slice();

--- a/modals/deckmodal.html
+++ b/modals/deckmodal.html
@@ -7,6 +7,13 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
+            <div class="mb-2">
+                <input type="file" id="deck-file-input" accept=".txt,.dec,.dck" class="d-none" onchange="importDeckFromFile(this.files[0])">
+                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="document.getElementById('deck-file-input').click()">
+                    Import from file
+                </button>
+                <small class="text-muted ms-2">.txt, .dec, .dck</small>
+            </div>
             <div class="row">
                 <div class="col-sm-6">
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- Add "Import from file" button to the deck modal supporting .txt, .dec, and .dck files (plain text, MTGO `SB:` prefix, and `Sideboard:` section headers)
- Fix library card not being clickable or draggable after deck load (bindCardActions/setupClickToDraw were called before the card was in the DOM)
- Fix sideboard cards appearing empty (used nonexistent `result.sideboardList` instead of `result.cards`)
- Fix card counter not applying on focusout (handler checked `event.key` which is undefined on focusout events)

## Test plan
- [x] Load a deck and verify library card can be clicked to draw and dragged to table
- [x] Press `d` to draw and verify new hand cards are draggable
- [x] Load a deck with sideboard and verify sideboard cards appear correctly
- [x] Add a counter to a card (`c`), set a value, click away, and verify it applies
- [x] Import a .txt deck file and verify mainboard/sideboard populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)