### PR TITLE
Add sideboard swap modal for game 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
                       <li><a class="dropdown-item" onclick="flipHand();">Flip hand</a></li>
                       <li><hr class="dropdown-divider"></li>
                       <li><a class="dropdown-item" onclick="restart();">Restart</a></li>
+                      <li><a class="dropdown-item" onclick="openSideboardModal();">Sideboard swaps</a></li>
                       <li><hr class="dropdown-divider"></li>
                       <li><a class="dropdown-item" onclick="spawnDice('d6');">Roll d6</a></li>
                       <li><a class="dropdown-item" onclick="spawnDice('d20');">Roll d20</a></li>

--- a/js/goldfish.js
+++ b/js/goldfish.js
@@ -26,7 +26,7 @@ async function loadModals() {
     // If modals are already inlined (dist build), skip loading
     if (document.getElementById('deckModal')) return;
 
-    var modals = ['deckmodal', 'helpmodal', 'settingsmodal', 'shuffletocardmodal', 'tokenmodal', 'zonemodal'];
+    var modals = ['deckmodal', 'helpmodal', 'settingsmodal', 'shuffletocardmodal', 'tokenmodal', 'zonemodal', 'sideboardmodal'];
     await Promise.all(modals.map(async function(modal) {
         var response = await fetch('modals/' + modal + '.html');
         var html = await response.text();
@@ -600,6 +600,71 @@ function restart() {
     draw(7);
 
     bindCardActions();
+}
+
+// Working copies used while the sideboard modal is open
+var swapDeck = [];
+var swapSideboard = [];
+
+function openSideboardModal() {
+    swapDeck = deck.slice();
+    swapSideboard = sideboard.slice();
+    renderSideboardModal();
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('sideboardModal')).show();
+}
+
+function renderSideboardModal() {
+    renderSwapList('swap-main-list', swapDeck, swapSideboard);
+    renderSwapList('swap-side-list', swapSideboard, swapDeck);
+    document.getElementById('swap-main-count').textContent = swapDeck.length;
+    document.getElementById('swap-side-count').textContent = swapSideboard.length;
+}
+
+function renderSwapList(listId, fromList, toList) {
+    var ul = document.getElementById(listId);
+    ul.innerHTML = '';
+
+    // Aggregate unique card names with counts
+    var seen = {};
+    fromList.forEach(function(card) {
+        if (!seen[card.name]) seen[card.name] = { card: card, count: 0 };
+        seen[card.name].count++;
+    });
+
+    Object.keys(seen).sort().forEach(function(name) {
+        var entry = seen[name];
+        var li = document.createElement('li');
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.style.cursor = 'pointer';
+        li.title = 'Click to move one copy';
+
+        var nameSpan = document.createElement('span');
+        nameSpan.textContent = name;
+
+        var badge = document.createElement('span');
+        badge.className = 'badge bg-secondary';
+        badge.textContent = entry.count;
+
+        li.appendChild(nameSpan);
+        li.appendChild(badge);
+
+        li.addEventListener('click', function() {
+            var idx = fromList.findIndex(function(c) { return c.name === name; });
+            if (idx > -1) {
+                toList.push(fromList.splice(idx, 1)[0]);
+                renderSideboardModal();
+            }
+        });
+
+        ul.appendChild(li);
+    });
+}
+
+function applySideboardSwaps() {
+    deck = swapDeck;
+    sideboard = swapSideboard;
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('sideboardModal')).hide();
+    restart();
 }
 
 /**

--- a/modals/sideboardmodal.html
+++ b/modals/sideboardmodal.html
@@ -1,0 +1,28 @@
+<!-- Sideboard swaps modal -->
+<div id="sideboardModal" class="modal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Sideboard Swaps</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted small">Click a card to move it to the other list. Changes take effect when you start game 2.</p>
+                <div class="row">
+                    <div class="col-6">
+                        <h6>Mainboard (<span id="swap-main-count">0</span>)</h6>
+                        <ul id="swap-main-list" class="list-group list-group-flush"></ul>
+                    </div>
+                    <div class="col-6">
+                        <h6>Sideboard (<span id="swap-side-count">0</span>)</h6>
+                        <ul id="swap-side-list" class="list-group list-group-flush"></ul>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" onclick="applySideboardSwaps()">Start Game 2</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- New "Sideboard swaps" entry in the Actions dropdown (below Restart)
- Opens a modal showing mainboard and sideboard side by side as name/count lists
- Click any card to move one copy to the other list
- "Start Game 2" updates the base `deck` and `sideboard` arrays and restarts — the swapped configuration persists across subsequent restarts

## Test plan
- [x] Load a deck with sideboard, play game 1
- [x] Open Actions → Sideboard swaps, move some cards between lists, click Start Game 2
- [x] Verify the new game starts with the swapped configuration
- [x] Verify Restart after game 2 still uses the swapped lists (not the original)
- [x] Verify Cancel leaves the current game unchanged

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)